### PR TITLE
Fix gen_server exception handling

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -104,7 +104,8 @@ reload_slots_map(State) ->
 
 -spec get_cluster_slots([#node{}]) -> [[bitstring() | [bitstring()]]].
 get_cluster_slots([]) ->
-    throw({error,cannot_connect_to_cluster});
+    %% exit will be handled by eredis_cluster_pool:transaction/2
+    exit({error,cannot_connect_to_cluster});
 get_cluster_slots([Node|T]) ->
     case safe_eredis_start_link(Node#node.address, Node#node.port) of
         {ok,Connection} ->


### PR DESCRIPTION
Since 2014 gen_server converts throw/1 into a reply. Use exit/1 that is
handled already in eredis_cluster_pool:transaction/2.

See: https://medium.com/erlang-battleground/the-exceptional-server-abe9016ebe75